### PR TITLE
Add more manifests about configuring a Kubernetes cluster

### DIFF
--- a/manifests/cce-cloud-controller-manager-systemd-manifest
+++ b/manifests/cce-cloud-controller-manager-systemd-manifest
@@ -1,0 +1,21 @@
+[Unit]
+Description=Kubernetes Kubelet
+After=kube-apiserver.service
+
+[Service]
+ExecStart=/opt/kube/bin/kube-cloud-controller-manager \
+--allocate-node-cidrs=true \
+--cloud-config=/etc/kubernetes/cloud.config \
+--cloud-provider=cce \
+--cluster-cidr=172.29.0.0/16 \
+--cluster-name=kubernetes \
+--kubeconfig=/root/.kube/config \
+--leader-elect=true \
+--logtostderr=true \
+--route-reconciliation-period=50s \
+--v=4
+Restart=always
+Type=simple
+LimitNOFILE=65536
+
+[Install]

--- a/manifests/cce-kube-apiserver-systemd-manifest
+++ b/manifests/cce-kube-apiserver-systemd-manifest
@@ -1,0 +1,41 @@
+[Unit]
+Description=Kubernetes API Server
+After=network.target
+After=etcd.service
+
+[Service]
+ExecStart=/opt/kube/bin/kube-apiserver \
+--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,PodPreset,Initializers \
+--advertise-address=100.0.0.59 \
+--allow-privileged=true \
+--apiserver-count=3 \
+--authorization-mode=RBAC,Node \
+--bind-address=100.0.0.59 \
+--client-ca-file=/etc/kubernetes/pki/ca.pem \
+--cloud-config=/etc/kubernetes/cloud.config \
+--enable-swagger-ui=true \
+--etcd-cafile=/etc/etcd/ssl/ca.pem \
+--etcd-certfile=/etc/etcd/ssl/etcd.pem \
+--etcd-keyfile=/etc/etcd/ssl/etcd-key.pem \
+--etcd-servers=https://100.0.0.58:2379,https://100.0.0.60:2379,https://100.0.0.59:2379 \
+--enable-bootstrap-token-auth=true \
+--external-hostname=100.0.0.59  \
+--feature-gates=DevicePlugins=true,RotateKubeletServerCertificate=true,MountPropagation=true,CSIPersistentVolume=true \
+--insecure-port=0 \
+--logtostderr=true \
+--runtime-config=settings.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1alpha1=true,storage.k8s.io/v1alpha1=true \
+--secure-port=6443 \
+--service-account-key-file=/etc/kubernetes/pki/ca-key.pem \
+--service-cluster-ip-range=172.16.0.0/16 \
+--storage-backend=etcd3 \
+--tls-cert-file=/etc/kubernetes/pki/apiserver.pem \
+--tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem \
+--kubelet-client-certificate=/etc/kubernetes/pki/ca.pem \
+--kubelet-client-key=/etc/kubernetes/pki/ca-key.pem \
+--v=4
+Restart=always
+Type=notify
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/manifests/cce-kube-controller-manager-systemd-manifest
+++ b/manifests/cce-kube-controller-manager-systemd-manifest
@@ -1,0 +1,32 @@
+[Unit]
+Description=Kubernetes Controller Manager
+After=network.target
+After=kube-apiserver.service
+
+[Service]
+ExecStart=/opt/kube/bin/kube-controller-manager \
+--allocate-node-cidrs=true \
+--cloud-config=/etc/kubernetes/cloud.config \
+--cluster-cidr=172.29.0.0/16 \
+--cluster-name=kubernetes \
+--cluster-signing-cert-file=/etc/kubernetes/pki/ca.pem \
+--cluster-signing-key-file=/etc/kubernetes/pki/ca-key.pem \
+--controllers=*,bootstrapsigner,tokencleaner \
+--feature-gates=DevicePlugins=true,RotateKubeletServerCertificate=true,MountPropagation=true,CSIPersistentVolume=true \
+--insecure-experimental-approve-all-kubelet-csrs-for-group=system:bootstrappers \
+--kubeconfig=/etc/kubernetes/controller-manager.conf \
+--leader-elect=true \
+--logtostderr=true \
+--master=https://100.0.0.59:6443 \
+--root-ca-file=/etc/kubernetes/pki/ca.pem \
+--route-reconciliation-period=50s \
+--service-account-private-key-file=/etc/kubernetes/pki/ca-key.pem \
+--service-cluster-ip-range=172.16.0.0/16 \
+--use-service-account-credentials=true \
+--v=4
+Restart=always
+Type=simple
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/manifests/cce-kubelet-systemd-manifest
+++ b/manifests/cce-kubelet-systemd-manifest
@@ -1,0 +1,38 @@
+[Unit]
+Description=Kubernetes Kubelet
+After=docker.service
+Requires=docker.service
+
+[Service]
+ExecStart=/opt/kube/bin/kubelet \
+--address=192.168.3.16 \
+--allow-privileged=true \
+--client-ca-file=/etc/kubernetes/pki/ca.pem \
+--cloud-config=/etc/kubernetes/cloud.config \
+--cloud-provider=external \
+--cluster-dns=172.16.0.10 \
+--cluster-domain=cluster.local \
+--docker-root=/var/lib/docker \
+--fail-swap-on=false \
+--feature-gates=DevicePlugins=true,RotateKubeletServerCertificate=true,MountPropagation=true,CSIPersistentVolume=true \
+--hostname-override=192.168.3.16 \
+--kubeconfig=/etc/kubernetes/kubelet.conf \
+--logtostderr=true \
+--network-plugin=kubenet \
+--non-masquerade-cidr=172.29.0.0/16 \
+--pod-infra-container-image=hub-readonly.baidubce.com/public/pause:2.0 \
+--pod-manifest-path=/etc/kubernetes/manifests \
+--anonymous-auth=false \
+--v=4 \
+--enforce-node-allocatable=pods \
+--eviction-hard=memory.available<5%,nodefs.available<10%,imagefs.available<10% \
+--eviction-soft=memory.available<10%,nodefs.available<15%,imagefs.available<15% \
+--eviction-soft-grace-period=memory.available=2m,nodefs.available=2m,imagefs.available=2m \
+--eviction-max-pod-grace-period=30 \
+--eviction-minimum-reclaim=memory.available=0Mi,nodefs.available=500Mi,imagefs.available=500Mi
+
+Restart=always
+Type=simple
+LimitNOFILE=65536
+
+[Install]


### PR DESCRIPTION
This PR:
Add more manifests that describes how to configure a Kubernetes cluster on out-of-tree cloud provider as described in [cloud-provider-documentation](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0019-cloud-provider-documentation.md#goal-2).