### PR TITLE
Remove unused ScrubDNS interface from cloudprovider

### DIFF
--- a/pkg/cloud-provider/cce.go
+++ b/pkg/cloud-provider/cce.go
@@ -133,11 +133,6 @@ func (bc *BCECloud) Routes() (cloudprovider.Routes, bool) {
 	return bc, true
 }
 
-// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
-func (bc *BCECloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
-	return nameservers, searches
-}
-
 // ProviderName returns the cloud provider ID.
 func (bc *BCECloud) ProviderName() string {
 	return ProviderName


### PR DESCRIPTION
**What this PR does / why we need it:**
DNS scrubber from kubelet has been removed and cloudprovider's ScrubDNS() interface is not used anywhere.
See: https://github.com/kubernetes/kubernetes/pull/56955