### PR TITLE
fix issue#56 return nil when there is not existing eip

### DIFF
--- a/pkg/cloud-provider/load_balancer.go
+++ b/pkg/cloud-provider/load_balancer.go
@@ -232,8 +232,10 @@ func (bc *Baiducloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName
 		if len(targetEip) == 0 { // P1: use BLB public ip
 			targetEip = lb.PublicIp
 		}
+		//users may unbind eip manually
 		if len(targetEip) == 0 { // get none EIP
-			return fmt.Errorf("EnsureLoadBalancerDeleted failed: can not get a EIP to delete")
+			glog.V(3).Infof("Eip does not exist, Delete completed ")
+			return nil
 		}
 
 		// blb if has eip in the begin


### PR DESCRIPTION
指定BLB时，在控制台删除BLB不影响LB的删除与创建，但是此时在控制台解绑EIP与BLB，然后删除该LB会出现错误死循环。在查询到EIP不存在时返回nil。