### PR TITLE
fix: parse providerID error

### DIFF
--- a/pkg/cloud-provider/instances.go
+++ b/pkg/cloud-provider/instances.go
@@ -138,6 +138,10 @@ func (bc *Baiducloud) CurrentNodeName(ctx context.Context, hostname string) (typ
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (bc *Baiducloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	// when node.spec.providerID is not set, providerID is only instanceID, not start with cce://
+	if !strings.HasPrefix(providerID, bc.ProviderName() + "://") {
+		providerID = bc.ProviderName() + "://" + providerID
+	}
 	splitted := strings.Split(providerID, "//")
 	if len(splitted) != 2 {
 		return false, fmt.Errorf("parse ProviderID failed: %v", providerID)

--- a/pkg/cloud-provider/load_balancer_blb_backend_server.go
+++ b/pkg/cloud-provider/load_balancer_blb_backend_server.go
@@ -48,7 +48,7 @@ func (bc *Baiducloud) reconcileBackendServers(service *v1.Service, nodes []*v1.N
 	var candidateBackends []blb.BackendServer
 	for _, node := range nodes {
 		splitted := strings.Split(node.Spec.ProviderID, "//")
-		if len(splitted) < 1 {
+		if len(splitted) != 2 {
 			glog.Warningf("node %s has no spec.providerId", node.Name)
 			continue
 		}


### PR DESCRIPTION
1. BLB 同步 RS 时，处理 split providerID 错误
2. InstanceExistsByProviderID 的入参 providerID 可能为 instanceID，不以 cce:// 开头
Error getting data for node *** from cloud: parse ProviderID failed: <instance-id>
