### PR TITLE
pkg/service: remove inactive members from OWNERS

### DIFF
--- a/pkg/service/OWNERS
+++ b/pkg/service/OWNERS
@@ -4,15 +4,16 @@ reviewers:
 - bowei
 - MrHohn
 - thockin
-- matchstick
 - andrewsykim
 - cheftako
 approvers:
 - bowei
 - MrHohn
 - thockin
-- matchstick
 - andrewsykim
 - cheftako
 labels:
 - sig/network
+
+emeritus_approvers:
+- matchstick


### PR DESCRIPTION
For kubernetes/org#2013

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes matchstick from
the pkg/service/OWNERS file.

/assign @andrewsykim @tizhou86
cc @mrbobbytables @matchstick 